### PR TITLE
Correct blobPropertyBag override logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,7 @@ export const ReactMediaRecorder = ({
 
   const onRecordingStop = () => {
     const blobProperty: BlobPropertyBag =
-      blobPropertyBag || video ? { type: "video/mp4" } : { type: "audio/wav" };
+      blobPropertyBag || (video ? { type: "video/mp4" } : { type: "audio/wav" });
     const blob = new Blob(mediaChunks.current, blobProperty);
     const url = URL.createObjectURL(blob);
     setStatus("stopped");


### PR DESCRIPTION
A non-null `blobPropertyBag` value should replace any default values.

Current logic incorrectly `or`s `blobPropertyBag` and `video` together to determine which default to include.