### PR TITLE
Add Blob params to onStop in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ default: `{}`
 
 #### onStop
 
-A `function` that would get invoked when the MediaRecorder stops. It'll provide the blob url as its param.
+A `function` that would get invoked when the MediaRecorder stops. It'll provide the blob and the blob url as its params.
 
-type: `function(blobUrl: string)`  
+type: `function(blobUrl: string, blob: Blob)`  
 default: `() => null`
 
 #### render


### PR DESCRIPTION
thanks for the package :)

I was using it, and I wanted to get the [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) object itself not the URL, I went through the code and found that the `onStop` function does that.

https://github.com/MohammedAl-Rowad/react-media-recorder/blob/e5665429fc21540c099d194f053a7da7c840689f/src/index.ts#L18-L25


<img width="559" alt="Screen Shot 2021-04-14 at 10 43 35 AM" src="https://user-images.githubusercontent.com/38977667/114672880-494fc680-9d0e-11eb-92b5-0f6bd513dda9.png">


**so this PR to add this information to the docs**
