### PR TITLE
Use npm prepare instead of prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc && jsmin -o ./lib/index.js ./lib/index.js",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "files": [
     "lib"


### PR DESCRIPTION
This will build the package also when installing from git, i.e. on `npm install` when giving the git repo as dependency.