### PR TITLE
Clear stream ref after stopped and extend returned props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export type ReactMediaRecorderHookProps = {
   video?: boolean | MediaTrackConstraints;
   screen?: boolean;
   onStop?: (blobUrl: string, blob: Blob) => void;
+  onStart?: () => void;
   blobPropertyBag?: BlobPropertyBag;
   mediaRecorderOptions?: MediaRecorderOptions | null;
 };
@@ -57,6 +58,7 @@ export function useReactMediaRecorder({
   audio = true,
   video = false,
   onStop = () => null,
+  onStart = () => null,
   blobPropertyBag,
   screen = false,
   mediaRecorderOptions = null,
@@ -117,7 +119,8 @@ export function useReactMediaRecorder({
     }
 
     const checkConstraints = (mediaType: MediaTrackConstraints) => {
-      const supportedMediaConstraints = navigator.mediaDevices.getSupportedConstraints();
+      const supportedMediaConstraints =
+        navigator.mediaDevices.getSupportedConstraints();
       const unSupportedConstraints = Object.keys(mediaType).filter(
         (constraint) =>
           !(supportedMediaConstraints as { [key: string]: any })[constraint]
@@ -165,6 +168,7 @@ export function useReactMediaRecorder({
       mediaRecorder.current = new MediaRecorder(mediaStream.current);
       mediaRecorder.current.ondataavailable = onRecordingActive;
       mediaRecorder.current.onstop = onRecordingStop;
+      mediaRecorder.current.onstart = onRecordingStart;
       mediaRecorder.current.onerror = () => {
         setError("NO_RECORDER");
         setStatus("idle");
@@ -174,6 +178,9 @@ export function useReactMediaRecorder({
     }
   };
 
+  const onRecordingStart = () => {
+    onStart();
+  };
   const onRecordingActive = ({ data }: BlobEvent) => {
     mediaChunks.current.push(data);
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,14 @@ export type ReactMediaRecorderRenderProps = {
   pauseRecording: () => void;
   resumeRecording: () => void;
   stopRecording: () => void;
+  cancelRecording: () => void;
   mediaBlobUrl: null | string;
+  mediaBlob: null | Blob;
   status: StatusMessages;
   isAudioMuted: boolean;
   previewStream: MediaStream | null;
   clearBlobUrl: () => void;
+  clearBlob: () => void;
 };
 
 export type ReactMediaRecorderHookProps = {
@@ -69,6 +72,7 @@ export function useReactMediaRecorder({
   const [status, setStatus] = useState<StatusMessages>("idle");
   const [isAudioMuted, setIsAudioMuted] = useState<boolean>(false);
   const [mediaBlobUrl, setMediaBlobUrl] = useState<string | null>(null);
+  const [mediaBlob, setMediaBlob] = useState<Blob | null>(null);
   const [error, setError] = useState<keyof typeof RecorderErrors>("NONE");
 
   const getMediaStream = useCallback(async () => {
@@ -195,6 +199,7 @@ export function useReactMediaRecorder({
     const url = URL.createObjectURL(blob);
     setStatus("stopped");
     setMediaBlobUrl(url);
+    setMediaBlob(blob);
     onStop(url, blob);
   };
 
@@ -231,6 +236,15 @@ export function useReactMediaRecorder({
     }
   };
 
+  const cancelRecording = () => {
+    mediaRecorder.current = null;
+    mediaStream.current = null;
+    mediaChunks.current = [];
+    setMediaBlobUrl(null);
+    setMediaBlob(null);
+    setStatus("stopped");
+  };
+
   return {
     error: RecorderErrors[error],
     muteAudio: () => muteAudio(true),
@@ -239,13 +253,16 @@ export function useReactMediaRecorder({
     pauseRecording,
     resumeRecording,
     stopRecording,
+    cancelRecording,
     mediaBlobUrl,
+    mediaBlob,
     status,
     isAudioMuted,
     previewStream: mediaStream.current
       ? new MediaStream(mediaStream.current.getVideoTracks())
       : null,
     clearBlobUrl: () => setMediaBlobUrl(null),
+    clearBlob: () => setMediaBlob(null),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,10 +146,6 @@ export function useReactMediaRecorder({
         );
       }
     }
-
-    if (!mediaStream.current) {
-      getMediaStream();
-    }
   }, [audio, screen, video, getMediaStream, mediaRecorderOptions]);
 
   // Media Recorder Handlers
@@ -223,6 +219,7 @@ export function useReactMediaRecorder({
         mediaStream.current &&
           mediaStream.current.getTracks().forEach((track) => track.stop());
         mediaChunks.current = [];
+        mediaStream.current = null;
       }
     }
   };


### PR DESCRIPTION
When using this library on a project I encountered the same (tiny) issues as described in #26 and #29.

I'm opening the PR out of concern for UX. Privacy is a sensitive issue, and as a user, I want to feel in control of when and why I'm sharing media with a site.