### PR TITLE
Reset to initial “idle” state in clearBlogUrl()

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ A `blob` url that can be wired to an `<audio />`, `<video />` or an `<a />` elem
 
 #### clearBlobUrl
 
-A `function` which clears the existing generated blob url (if any)
+A `function` which clears the existing generated blob url (if any) and resets the workflow to its initial `idle` state.
 
 #### isMuted
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,7 @@ export function useReactMediaRecorder({
         URL.revokeObjectURL(mediaBlobUrl);
       }
       setMediaBlobUrl(null);
+      setStatus('idle');
     },
   };
 }


### PR DESCRIPTION
Closes #64 (part 2).