### PR TITLE
Support all browsers when recording is disabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ export function useReactMediaRecorder({
   }, [audio, video, screen]);
 
   useEffect(() => {
-    if (!window.MediaRecorder) {
+    if (!window.MediaRecorder && (screen || audio)) {
       throw new Error("Unsupported Browser");
     }
 


### PR DESCRIPTION
This allow to use react-media-recorder with all kind of browser and handle browser incompatibility thanks to undefined audio & video.