### PR TITLE
fix: use media recorder option in MediaRecorder constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ export function useReactMediaRecorder({
       if (!mediaStream.current.active) {
         return;
       }
-      mediaRecorder.current = new MediaRecorder(mediaStream.current);
+      mediaRecorder.current = new MediaRecorder(mediaStream.current, mediaRecorderOptions || undefined);
       mediaRecorder.current.ondataavailable = onRecordingActive;
       mediaRecorder.current.onstop = onRecordingStop;
       mediaRecorder.current.onerror = () => {


### PR DESCRIPTION
The media recorder options are not properly passed through to the `new MediaRecorder()` instance